### PR TITLE
Add `nextpnr-himbaechel` to the package

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ NAME=oss-cad-suite
 # -- If you want to genete an updated oss-cad-suite apio packages
 # -- set the new date
 YEAR=2024
-MONTH=02
+MONTH=06
 DAY=08
 
 # -- Set the version for the new package

--- a/build.sh
+++ b/build.sh
@@ -21,8 +21,8 @@ NAME=oss-cad-suite
 # -- If you want to genete an updated oss-cad-suite apio packages
 # -- set the new date
 YEAR=2024
-MONTH=06
-DAY=08
+MONTH=08
+DAY=02
 
 # -- Set the version for the new package
 VERSION=0.1.0

--- a/scripts/install_darwin.sh
+++ b/scripts/install_darwin.sh
@@ -105,6 +105,15 @@ install $SOURCE_DIR/bin/nextpnr-ecp5 $PACKAGE_DIR/bin
 install $SOURCE_DIR/libexec/nextpnr-ecp5 $PACKAGE_DIR/libexec
 
 
+#------------------------------------------
+#-- Gowin tools
+#------------------------------------------
+# -----------------------------------
+# -- NETXPNR-Gowin
+# -----------------------------------
+install $SOURCE_DIR/bin/nextpnr-gowin $PACKAGE_DIR/bin
+install $SOURCE_DIR/libexec/nextpnr-gowin $PACKAGE_DIR/libexec
+
 #-------------------------------------------------------------
 #-- PROGRAMMERS!!
 #-------------------------------------------------------------

--- a/scripts/install_darwin.sh
+++ b/scripts/install_darwin.sh
@@ -111,8 +111,8 @@ install $SOURCE_DIR/libexec/nextpnr-ecp5 $PACKAGE_DIR/libexec
 # -----------------------------------
 # -- NETXPNR-Gowin
 # -----------------------------------
-install $SOURCE_DIR/bin/nextpnr-gowin $PACKAGE_DIR/bin
-install $SOURCE_DIR/libexec/nextpnr-gowin $PACKAGE_DIR/libexec
+install $SOURCE_DIR/bin/nextpnr-himbaechel $PACKAGE_DIR/bin
+install $SOURCE_DIR/libexec/nextpnr-himbaechel $PACKAGE_DIR/libexec
 
 #-------------------------------------------------------------
 #-- PROGRAMMERS!!

--- a/scripts/install_darwin.sh
+++ b/scripts/install_darwin.sh
@@ -114,6 +114,13 @@ install $SOURCE_DIR/libexec/nextpnr-ecp5 $PACKAGE_DIR/libexec
 install $SOURCE_DIR/bin/nextpnr-himbaechel $PACKAGE_DIR/bin
 install $SOURCE_DIR/libexec/nextpnr-himbaechel $PACKAGE_DIR/libexec
 
+
+#------------------------------------------
+#-- Nextpnr Share
+#------------------------------------------
+mkdir -p $PACKAGE_DIR/share/nextpnr
+cp -r $SOURCE_DIR/share/nextpnr/* $PACKAGE_DIR/share/nextpnr
+
 #-------------------------------------------------------------
 #-- PROGRAMMERS!!
 #-------------------------------------------------------------

--- a/scripts/install_darwin_arm64.sh
+++ b/scripts/install_darwin_arm64.sh
@@ -106,6 +106,16 @@ install $SOURCE_DIR/bin/nextpnr-ecp5 $PACKAGE_DIR/bin
 install $SOURCE_DIR/libexec/nextpnr-ecp5 $PACKAGE_DIR/libexec
 
 
+
+#------------------------------------------
+#-- Gowin tools
+#------------------------------------------
+# -----------------------------------
+# -- NETXPNR-Gowin
+# -----------------------------------
+install $SOURCE_DIR/bin/nextpnr-gowin $PACKAGE_DIR/bin
+install $SOURCE_DIR/libexec/nextpnr-gowin $PACKAGE_DIR/libexec
+
 #-------------------------------------------------------------
 #-- PROGRAMMERS!!
 #-------------------------------------------------------------

--- a/scripts/install_darwin_arm64.sh
+++ b/scripts/install_darwin_arm64.sh
@@ -110,11 +110,20 @@ install $SOURCE_DIR/libexec/nextpnr-ecp5 $PACKAGE_DIR/libexec
 #------------------------------------------
 #-- Gowin tools
 #------------------------------------------
+
 # -----------------------------------
 # -- NETXPNR-Gowin
 # -----------------------------------
 install $SOURCE_DIR/bin/nextpnr-himbaechel $PACKAGE_DIR/bin
 install $SOURCE_DIR/libexec/nextpnr-himbaechel $PACKAGE_DIR/libexec
+
+
+
+#------------------------------------------
+#-- Nextpnr Share
+#------------------------------------------
+mkdir -p $PACKAGE_DIR/share/nextpnr
+cp -r $SOURCE_DIR/share/nextpnr/* $PACKAGE_DIR/share/nextpnr
 
 #-------------------------------------------------------------
 #-- PROGRAMMERS!!

--- a/scripts/install_darwin_arm64.sh
+++ b/scripts/install_darwin_arm64.sh
@@ -113,8 +113,8 @@ install $SOURCE_DIR/libexec/nextpnr-ecp5 $PACKAGE_DIR/libexec
 # -----------------------------------
 # -- NETXPNR-Gowin
 # -----------------------------------
-install $SOURCE_DIR/bin/nextpnr-gowin $PACKAGE_DIR/bin
-install $SOURCE_DIR/libexec/nextpnr-gowin $PACKAGE_DIR/libexec
+install $SOURCE_DIR/bin/nextpnr-himbaechel $PACKAGE_DIR/bin
+install $SOURCE_DIR/libexec/nextpnr-himbaechel $PACKAGE_DIR/libexec
 
 #-------------------------------------------------------------
 #-- PROGRAMMERS!!

--- a/scripts/install_linux_arm64.sh
+++ b/scripts/install_linux_arm64.sh
@@ -138,8 +138,8 @@
 # -----------------------------------
 # -- NETXPNR-Gowin
 # -----------------------------------
-install $SOURCE_DIR/bin/nextpnr-gowin $PACKAGE_DIR/bin
-install $SOURCE_DIR/libexec/nextpnr-gowin $PACKAGE_DIR/libexec
+install $SOURCE_DIR/bin/nextpnr-himbaechel $PACKAGE_DIR/bin
+install $SOURCE_DIR/libexec/nextpnr-himbaechel $PACKAGE_DIR/libexec
 
 #-------------------------------------------------------------
 #-- PROGRAMMERS!!

--- a/scripts/install_linux_arm64.sh
+++ b/scripts/install_linux_arm64.sh
@@ -141,6 +141,14 @@
 install $SOURCE_DIR/bin/nextpnr-himbaechel $PACKAGE_DIR/bin
 install $SOURCE_DIR/libexec/nextpnr-himbaechel $PACKAGE_DIR/libexec
 
+
+#------------------------------------------
+#-- Nextpnr Share
+#------------------------------------------
+mkdir -p $PACKAGE_DIR/share/nextpnr
+cp -r $SOURCE_DIR/share/nextpnr/* $PACKAGE_DIR/share/nextpnr
+
+
 #-------------------------------------------------------------
 #-- PROGRAMMERS!!
 #-------------------------------------------------------------

--- a/scripts/install_linux_arm64.sh
+++ b/scripts/install_linux_arm64.sh
@@ -132,6 +132,15 @@
   install $SOURCE_DIR/bin/nextpnr-ecp5 $PACKAGE_DIR/bin
   install $SOURCE_DIR/libexec/nextpnr-ecp5 $PACKAGE_DIR/libexec
 
+#------------------------------------------
+#-- Gowin tools
+#------------------------------------------
+# -----------------------------------
+# -- NETXPNR-Gowin
+# -----------------------------------
+install $SOURCE_DIR/bin/nextpnr-gowin $PACKAGE_DIR/bin
+install $SOURCE_DIR/libexec/nextpnr-gowin $PACKAGE_DIR/libexec
+
 #-------------------------------------------------------------
 #-- PROGRAMMERS!!
 #-------------------------------------------------------------

--- a/scripts/install_linux_x64.sh
+++ b/scripts/install_linux_x64.sh
@@ -92,6 +92,15 @@ cp -r $SOURCE_DIR/share/trellis/* $PACKAGE_DIR/share/trellis
 install $SOURCE_DIR/bin/nextpnr-ecp5 $PACKAGE_DIR/bin
 install $SOURCE_DIR/libexec/nextpnr-ecp5 $PACKAGE_DIR/libexec
 
+#------------------------------------------
+#-- Gowin tools
+#------------------------------------------
+# -----------------------------------
+# -- NETXPNR-Gowin
+# -----------------------------------
+install $SOURCE_DIR/bin/nextpnr-gowin $PACKAGE_DIR/bin
+install $SOURCE_DIR/libexec/nextpnr-gowin $PACKAGE_DIR/libexec
+
 #-------------------------------------------------------------
 #-- PROGRAMMERS!!
 #-------------------------------------------------------------

--- a/scripts/install_linux_x64.sh
+++ b/scripts/install_linux_x64.sh
@@ -98,8 +98,8 @@ install $SOURCE_DIR/libexec/nextpnr-ecp5 $PACKAGE_DIR/libexec
 # -----------------------------------
 # -- NETXPNR-Gowin
 # -----------------------------------
-install $SOURCE_DIR/bin/nextpnr-gowin $PACKAGE_DIR/bin
-install $SOURCE_DIR/libexec/nextpnr-gowin $PACKAGE_DIR/libexec
+install $SOURCE_DIR/bin/nextpnr-himbaechel $PACKAGE_DIR/bin
+install $SOURCE_DIR/libexec/nextpnr-himbaechel $PACKAGE_DIR/libexec
 
 #-------------------------------------------------------------
 #-- PROGRAMMERS!!

--- a/scripts/install_linux_x64.sh
+++ b/scripts/install_linux_x64.sh
@@ -101,6 +101,12 @@ install $SOURCE_DIR/libexec/nextpnr-ecp5 $PACKAGE_DIR/libexec
 install $SOURCE_DIR/bin/nextpnr-himbaechel $PACKAGE_DIR/bin
 install $SOURCE_DIR/libexec/nextpnr-himbaechel $PACKAGE_DIR/libexec
 
+#------------------------------------------
+#-- Nextpnr Share
+#------------------------------------------
+mkdir -p $PACKAGE_DIR/share/nextpnr
+cp -r $SOURCE_DIR/share/nextpnr/* $PACKAGE_DIR/share/nextpnr
+
 #-------------------------------------------------------------
 #-- PROGRAMMERS!!
 #-------------------------------------------------------------

--- a/scripts/install_windows_x64.sh
+++ b/scripts/install_windows_x64.sh
@@ -99,6 +99,12 @@ install $SOURCE_DIR/bin/nextpnr-ecp5.exe $PACKAGE_DIR/bin
 # -----------------------------------
 install $SOURCE_DIR/bin/nextpnr-himbaechel.exe $PACKAGE_DIR/bin
 
+#------------------------------------------
+#-- Nextpnr Share
+#------------------------------------------
+mkdir -p $PACKAGE_DIR/share/nextpnr
+cp -r $SOURCE_DIR/share/nextpnr/* $PACKAGE_DIR/share/nextpnr
+
 # ---------------------------------------------------------
 # -- SIMULATION!!
 # ---------------------------------------------------------

--- a/scripts/install_windows_x64.sh
+++ b/scripts/install_windows_x64.sh
@@ -97,7 +97,7 @@ install $SOURCE_DIR/bin/nextpnr-ecp5.exe $PACKAGE_DIR/bin
 # -----------------------------------
 # -- NETXPNR-Gowin
 # -----------------------------------
-install $SOURCE_DIR/bin/nextpnr-gowin.exe $PACKAGE_DIR/bin
+install $SOURCE_DIR/bin/nextpnr-himbaechel.exe $PACKAGE_DIR/bin
 
 # ---------------------------------------------------------
 # -- SIMULATION!!

--- a/scripts/install_windows_x64.sh
+++ b/scripts/install_windows_x64.sh
@@ -91,6 +91,14 @@ cp -r $SOURCE_DIR/share/trellis/* $PACKAGE_DIR/share/trellis
 install $SOURCE_DIR/bin/nextpnr-ecp5.exe $PACKAGE_DIR/bin
 
 
+#------------------------------------------
+#-- Gowin tools
+#------------------------------------------
+# -----------------------------------
+# -- NETXPNR-Gowin
+# -----------------------------------
+install $SOURCE_DIR/bin/nextpnr-gowin.exe $PACKAGE_DIR/bin
+
 # ---------------------------------------------------------
 # -- SIMULATION!!
 # ---------------------------------------------------------


### PR DESCRIPTION
This pull request updates the installation scripts to copy over `nextpnr-himbaechel` and related files, enabling future support for Gowin FPGAs.

Additionally, this pull request updates the oss-cad-suite tools to the August 2nd 2024 Nightly release, as the previously used version was raising assertion errors when running `nextpnr-himbaechel`. 

This pull request was created to support FPGAwars/apio#390