### PR TITLE
Added the gtkwave files to the oss-cad-suite package (darwin and darwin_arm64 only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _upstream/
 _packages/
 VERSION_BUILD
 .run.sh
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _upstream/
 _packages/
 VERSION_BUILD
+.run.sh

--- a/build.sh
+++ b/build.sh
@@ -352,8 +352,8 @@ echo ""
 echo ""
 PACKAGE_JSON="$PACKAGE_DIR"/package.json
 cp -r "$WORK_DIR"/build-data/templates/package-template.json $PACKAGE_JSON
-sed -i "s/%VERSION%/\"$VERSION\"/;" "$PACKAGE_DIR"/package.json
-sed -i "s/%SYSTEM%/\"$ARCH\"/;" "$PACKAGE_DIR"/package.json
+sed -i "" "s/%VERSION%/\"$VERSION\"/;" "$PACKAGE_DIR"/package.json
+sed -i "" "s/%SYSTEM%/\"$ARCH\"/;" "$PACKAGE_DIR"/package.json
 
 cd $PACKAGE_DIR
 

--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,18 @@
 #      oss cad suite Apio package builder   #
 #############################################
 
+# Mac OSX Note:
+# Install 7-zip and create for it a symling claled '7z':
+#
+# brew 7-zip
+# ln -s /opt/homebrew/bin/7zz /opt/homebrew/bin/7z
+
+# For debugging, echo executed commands.
+# set -x
+
+# Exit on any error
+set -e
+
 # Set english language for propper pattern matching
 export LC_ALL=C
 
@@ -244,7 +256,7 @@ fi
 # -- (not available in the oss-cad-suite)
 # -- (Not avaialbe for arm-64)
 
-if [ "${ARCH}" == "darwin_arm64" || "${ARCH}" == "linux_aarch64" ]; then
+if [ "${ARCH}" == "darwin_arm64" ] || [ "${ARCH}" == "linux_aarch64" ]; then
   echo ""
   echo "---> ARM 64 HAS NOT TOOL-SYSTEM PACKAGE"
   echo ""

--- a/scripts/install_darwin.sh
+++ b/scripts/install_darwin.sh
@@ -108,6 +108,7 @@ install $SOURCE_DIR/libexec/nextpnr-ecp5 $PACKAGE_DIR/libexec
 #------------------------------------------
 #-- Gowin tools
 #------------------------------------------
+
 # -----------------------------------
 # -- NETXPNR-Gowin
 # -----------------------------------
@@ -179,4 +180,15 @@ install $SOURCE_DIR/bin/verilator_bin $PACKAGE_DIR/bin
 install $SOURCE_DIR/libexec/verilator_bin $PACKAGE_DIR/libexec/
 mkdir -p $PACKAGE_DIR/share/verilator/include
 install $SOURCE_DIR/share/verilator/include/verilated_std.sv $PACKAGE_DIR/share/verilator/include
+
+# --------------------------------------
+# -- gtkwave
+# --------------------------------------
+install $SOURCE_DIR/bin/gtkwave $PACKAGE_DIR/bin
+
+install $SOURCE_DIR/libexec/gtkwave $PACKAGE_DIR/libexec/
+install $SOURCE_DIR/libexec/gdk-pixbuf-query-loaders $PACKAGE_DIR/libexec/
+
+mkdir -p $PACKAGE_DIR/lib/gdk-pixbuf-2.0/loaders
+install $SOURCE_DIR/lib/gdk-pixbuf-2.0/loaders/* $PACKAGE_DIR/lib/gdk-pixbuf-2.0/loaders
 

--- a/scripts/install_darwin_arm64.sh
+++ b/scripts/install_darwin_arm64.sh
@@ -66,9 +66,8 @@ cp -r $SOURCE_DIR/share/icebox/* $PACKAGE_DIR/share/icebox
 install $TEMPLATE/nextpnr-ice40 $PACKAGE_DIR/bin
 install $SOURCE_DIR/libexec/nextpnr-ice40 $PACKAGE_DIR/libexec
 
-
 # -- Python 3.11
-# -- The whole python 3.8 should be copied in lib/python3.8
+# -- The whole python 3.11 should be copied in lib/python3.11
 mkdir -p $PACKAGE_DIR/lib/python3.11
 cp -r $SOURCE_DIR/lib/python3.11/* $PACKAGE_DIR/lib/python3.11
 
@@ -106,7 +105,6 @@ install $SOURCE_DIR/bin/nextpnr-ecp5 $PACKAGE_DIR/bin
 install $SOURCE_DIR/libexec/nextpnr-ecp5 $PACKAGE_DIR/libexec
 
 
-
 #------------------------------------------
 #-- Gowin tools
 #------------------------------------------
@@ -116,7 +114,6 @@ install $SOURCE_DIR/libexec/nextpnr-ecp5 $PACKAGE_DIR/libexec
 # -----------------------------------
 install $SOURCE_DIR/bin/nextpnr-himbaechel $PACKAGE_DIR/bin
 install $SOURCE_DIR/libexec/nextpnr-himbaechel $PACKAGE_DIR/libexec
-
 
 
 #------------------------------------------
@@ -183,4 +180,15 @@ install $SOURCE_DIR/bin/verilator_bin $PACKAGE_DIR/bin
 install $SOURCE_DIR/libexec/verilator_bin $PACKAGE_DIR/libexec/
 mkdir -p $PACKAGE_DIR/share/verilator/include
 install $SOURCE_DIR/share/verilator/include/verilated_std.sv $PACKAGE_DIR/share/verilator/include
+
+# --------------------------------------
+# -- gtkwave
+# --------------------------------------
+install $SOURCE_DIR/bin/gtkwave $PACKAGE_DIR/bin
+
+install $SOURCE_DIR/libexec/gtkwave $PACKAGE_DIR/libexec/
+install $SOURCE_DIR/libexec/gdk-pixbuf-query-loaders $PACKAGE_DIR/libexec/
+
+mkdir -p $PACKAGE_DIR/lib/gdk-pixbuf-2.0/loaders
+install $SOURCE_DIR/lib/gdk-pixbuf-2.0/loaders/* $PACKAGE_DIR/lib/gdk-pixbuf-2.0/loaders
 


### PR DESCRIPTION
Per the suggestion at https://github.com/FPGAwars/apio/issues/345#issuecomment-2020278009, added to the oss-cad-suite the gtkwave files.  This PR adds for dawrin and darwin_arm64 only. Will add to the rest of the architectures in follow up PRs.

Also, minor tweaks of the file buils.sh.