### PR TITLE
Changes to tools-oss-cad-suite packge

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -33,8 +33,8 @@ jobs:
         run: |
           ./build.sh linux_aarch64
 
-      # -- Build the package for darwin
-      - name: Build package darwin
+      # -- Build the package for darwin x64
+      - name: Build package [darwin] (x64)
         run: |
           ./build.sh darwin
 
@@ -43,7 +43,6 @@ jobs:
         run: |
           ./build.sh darwin_arm64
 
- 
       # -- Build the package for windows_amd64
       - name: Build package [windows_amd64]
         run: |

--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ VERSION=0.2.2
 # -- https://github.com/YosysHQ/oss-cad-suite-build/releases
 YEAR=2025
 MONTH=05
-DAY=20
+DAY=26
 
 # For debugging, echo executed commands.
 # set -x

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 #############################################
 #      oss cad suite Apio package builder   #
 #############################################
@@ -6,8 +6,8 @@
 # Mac OSX Note:
 # Install 7-zip and create for it a symling claled '7z':
 #
-# brew 7-zip
-# ln -s /opt/homebrew/bin/7zz /opt/homebrew/bin/7z
+#   brew install 7-zip
+#   ln -s /opt/homebrew/bin/7zz /opt/homebrew/bin/7z
 
 # -- Set the version the generated apio packages. This is
 # -- also used to derive the release id.

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@
 
 # -- Set the version the generated apio packages. This is
 # -- also used to derive the release id.
-VERSION=0.2.2
+VERSION=0.2.3
 
 # -- The version of the upstream oss-cad-suite to use, specified
 # -- as a date. See list here:

--- a/scripts/install_darwin.sh
+++ b/scripts/install_darwin.sh
@@ -9,7 +9,7 @@ rsync -a \
     $SOURCE_DIR/ $PACKAGE_DIR
 
 # -- Create an alias, per https://github.com/FPGAwars/apio/issues/608
-cp $PACKAGE_DIR/lib/libusb-1.0.0.dylib cp $PACKAGE_DIR/lib/libusb-1.0.dylib
+cp $PACKAGE_DIR/lib/libusb-1.0.0.dylib $PACKAGE_DIR/lib/libusb-1.0.dylib
 
 # -- Sanity checks
 assert_executable $PACKAGE_DIR/bin/yosys

--- a/scripts/install_darwin.sh
+++ b/scripts/install_darwin.sh
@@ -8,6 +8,9 @@ assert_dir_empty $PACKAGE_DIR
 rsync -a \
     $SOURCE_DIR/ $PACKAGE_DIR
 
+# -- Create an alias, per https://github.com/FPGAwars/apio/issues/608
+cp $PACKAGE_DIR/lib/libusb-1.0.0.dylib cp $PACKAGE_DIR/lib/libusb-1.0.dylib
+
 # -- Sanity checks
 assert_executable $PACKAGE_DIR/bin/yosys
 assert_executable $PACKAGE_DIR/bin/nextpnr-ice40 
@@ -15,3 +18,9 @@ assert_executable $PACKAGE_DIR/bin/nextpnr-ecp5
 assert_executable $PACKAGE_DIR/bin/nextpnr-himbaechel
 assert_executable $PACKAGE_DIR/bin/dot
 assert_executable $PACKAGE_DIR/bin/gtkwave
+
+assert_is_file $PACKAGE_DIR/lib/libusb-1.0.0.dylib
+assert_is_file $PACKAGE_DIR/lib/libusb-1.0.dylib
+
+
+

--- a/scripts/install_darwin_arm64.sh
+++ b/scripts/install_darwin_arm64.sh
@@ -9,7 +9,7 @@ rsync -a \
     $SOURCE_DIR/ $PACKAGE_DIR
 
 # -- Create an alias, per https://github.com/FPGAwars/apio/issues/608
-cp $PACKAGE_DIR/lib/libusb-1.0.0.dylib cp $PACKAGE_DIR/lib/libusb-1.0.dylib
+cp $PACKAGE_DIR/lib/libusb-1.0.0.dylib $PACKAGE_DIR/lib/libusb-1.0.dylib
 
 # -- Sanity checks
 assert_executable $PACKAGE_DIR/bin/yosys

--- a/scripts/install_darwin_arm64.sh
+++ b/scripts/install_darwin_arm64.sh
@@ -8,6 +8,9 @@ assert_dir_empty $PACKAGE_DIR
 rsync -a \
     $SOURCE_DIR/ $PACKAGE_DIR
 
+# -- Create an alias, per https://github.com/FPGAwars/apio/issues/608
+cp $PACKAGE_DIR/lib/libusb-1.0.0.dylib cp $PACKAGE_DIR/lib/libusb-1.0.dylib
+
 # -- Sanity checks
 assert_executable $PACKAGE_DIR/bin/yosys
 assert_executable $PACKAGE_DIR/bin/nextpnr-ice40 
@@ -15,3 +18,9 @@ assert_executable $PACKAGE_DIR/bin/nextpnr-ecp5
 assert_executable $PACKAGE_DIR/bin/nextpnr-himbaechel
 assert_executable $PACKAGE_DIR/bin/dot
 assert_executable $PACKAGE_DIR/bin/gtkwave
+
+assert_is_file $PACKAGE_DIR/lib/libusb-1.0.0.dylib
+assert_is_file $PACKAGE_DIR/lib/libusb-1.0.dylib
+
+
+


### PR DESCRIPTION
@cavearr, after you accept, please **run the release workflow  and publish manually version 0.2.3** it creates.


In this pull request:

1. Fixed https://github.com/FPGAwars/apio/issues/608

2. Switch to latest oss-cad-suite build to include this fiex  https://github.com/trabucayre/openFPGALoader/issues/554

3. Bumped package version to 0.2.3