### PR TITLE
Removed the libusb alias on darwin, it's not needed bacause DYLD_LIBR…

### DIFF
--- a/scripts/install_darwin.sh
+++ b/scripts/install_darwin.sh
@@ -8,9 +8,6 @@ assert_dir_empty $PACKAGE_DIR
 rsync -a \
     $SOURCE_DIR/ $PACKAGE_DIR
 
-# -- Create an alias, per https://github.com/FPGAwars/apio/issues/608
-cp $PACKAGE_DIR/lib/libusb-1.0.0.dylib $PACKAGE_DIR/lib/libusb-1.0.dylib
-
 # -- Sanity checks
 assert_executable $PACKAGE_DIR/bin/yosys
 assert_executable $PACKAGE_DIR/bin/nextpnr-ice40 
@@ -19,8 +16,8 @@ assert_executable $PACKAGE_DIR/bin/nextpnr-himbaechel
 assert_executable $PACKAGE_DIR/bin/dot
 assert_executable $PACKAGE_DIR/bin/gtkwave
 
+# -- Libusb backend.
 assert_is_file $PACKAGE_DIR/lib/libusb-1.0.0.dylib
-assert_is_file $PACKAGE_DIR/lib/libusb-1.0.dylib
 
 
 

--- a/scripts/install_darwin_arm64.sh
+++ b/scripts/install_darwin_arm64.sh
@@ -8,9 +8,6 @@ assert_dir_empty $PACKAGE_DIR
 rsync -a \
     $SOURCE_DIR/ $PACKAGE_DIR
 
-# -- Create an alias, per https://github.com/FPGAwars/apio/issues/608
-cp $PACKAGE_DIR/lib/libusb-1.0.0.dylib $PACKAGE_DIR/lib/libusb-1.0.dylib
-
 # -- Sanity checks
 assert_executable $PACKAGE_DIR/bin/yosys
 assert_executable $PACKAGE_DIR/bin/nextpnr-ice40 
@@ -19,8 +16,8 @@ assert_executable $PACKAGE_DIR/bin/nextpnr-himbaechel
 assert_executable $PACKAGE_DIR/bin/dot
 assert_executable $PACKAGE_DIR/bin/gtkwave
 
+# -- Libusb backend.
 assert_is_file $PACKAGE_DIR/lib/libusb-1.0.0.dylib
-assert_is_file $PACKAGE_DIR/lib/libusb-1.0.dylib
 
 
 


### PR DESCRIPTION
@cavearr, please **accept and run the ``build-and-release`` workflow.** It will update the files of 0.2.3.  **No need to publish manually** since we don't create a new release, just updating an existing one


Removed the libusb alias for darwin that was added in previous PR. It is not needed anymore now that we switch from DYLD_LIBRARY_PATH to explicit libusb backend search which works better on windows.