### PR TITLE
Restoring the commented out release tag reset step

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -144,10 +144,10 @@ jobs:
 
       # Commented out. This requires a stronger token to work.
       # In case we overwrite and exiting release.
-      # - name: Force tag update
-      #   run: |
-      #     git tag -f ${{env.RELEASE_TAG}}
-      #     git push origin -f ${{env.RELEASE_TAG}}
+      - name: Force tag update
+        run: |
+          git tag -f ${{env.RELEASE_TAG}}
+          git push origin -f ${{env.RELEASE_TAG}}
 
       # Scans recursively inside the .tgz packages.
       # See https://linux.die.net/man/1/clamscan


### PR DESCRIPTION
Hi @cavearr, please review and accept.

I commented it out because it failed earlier today but giving it a second chance. It does work on all the other builders.